### PR TITLE
Fix bug with missing parameters

### DIFF
--- a/aiolinkding/bookmark.py
+++ b/aiolinkding/bookmark.py
@@ -34,7 +34,7 @@ class BookmarkManager:
         if archived:
             endpoint += "archived/"
 
-        data = await self._async_request("get", endpoint)
+        data = await self._async_request("get", endpoint, params=params)
         return cast(Dict[str, Any], data)
 
     async def _async_create_or_update_bookmark(

--- a/aiolinkding/tag.py
+++ b/aiolinkding/tag.py
@@ -34,7 +34,7 @@ class TagManager:
             if kwarg:
                 params[param_name] = kwarg
 
-        data = await self._async_request("get", "/api/tags/")
+        data = await self._async_request("get", "/api/tags/", params=params)
         return cast(Dict[str, Any], data)
 
     async def async_get_single(self, tag_id: int) -> dict[str, Any]:

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -79,13 +79,14 @@ async def test_get_all(aresponses, bookmarks_async_get_all_response):
     """Test getting all bookmarks."""
     aresponses.add(
         "127.0.0.1:8000",
-        "/api/bookmarks/",
+        "/api/bookmarks/?limit=100",
         "get",
         aresponses.Response(
             text=json.dumps(bookmarks_async_get_all_response),
             status=200,
             headers={"Content-Type": "application/json"},
         ),
+        match_querystring=True,
     )
 
     async with aiohttp.ClientSession() as session:

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -37,13 +37,14 @@ async def test_get_all(aresponses, tags_async_get_all_response):
     """Test getting all tags."""
     aresponses.add(
         "127.0.0.1:8000",
-        "/api/tags/",
+        "/api/tags/?limit=100",
         "get",
         aresponses.Response(
             text=json.dumps(tags_async_get_all_response),
             status=200,
             headers={"Content-Type": "application/json"},
         ),
+        match_querystring=True,
     )
 
     async with aiohttp.ClientSession() as session:


### PR DESCRIPTION
**Describe what the PR does:**

This PR fixes a bug wherein `client.bookmarks.async_get_all()`, `client.bookmarks.async_get_archived()`, and `client.tags.async_get_all()` would any of the kwargs they are supposed to accept.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
