### PR TITLE
Fix "bug" with updating a bookmark

### DIFF
--- a/aiolinkding/bookmark.py
+++ b/aiolinkding/bookmark.py
@@ -38,35 +38,6 @@ class BookmarkManager:
         data = await self._async_request("get", endpoint, params=params)
         return cast(Dict[str, Any], data)
 
-    async def _async_create_or_update_bookmark(
-        self,
-        *,
-        url: str | None = None,
-        title: str | None = None,
-        description: str | None = None,
-        tag_names: list[str] | None = None,
-        bookmark_id: int | None = None,
-    ) -> dict[str, Any]:
-        """Create or update a bookmark."""
-        payload = generate_api_payload(
-            (
-                ("url", url),
-                ("title", title),
-                ("description", description),
-                ("tag_names", tag_names),
-            )
-        )
-
-        if bookmark_id:
-            method = "put"
-            url = f"/api/bookmarks/{bookmark_id}/"
-        else:
-            method = "post"
-            url = "/api/bookmarks/"
-
-        data = await self._async_request(method, url, json=payload)
-        return cast(Dict[str, Any], data)
-
     async def async_archive(self, bookmark_id: int) -> None:
         """Archive a bookmark."""
         await self._async_request("post", f"/api/bookmarks/{bookmark_id}/archive/")
@@ -106,9 +77,17 @@ class BookmarkManager:
         tag_names: list[str] | None = None,
     ) -> dict[str, Any]:
         """Create a new bookmark."""
-        return await self._async_create_or_update_bookmark(
-            url=url, title=title, description=description, tag_names=tag_names
+        payload = generate_api_payload(
+            (
+                ("url", url),
+                ("title", title),
+                ("description", description),
+                ("tag_names", tag_names),
+            )
         )
+
+        data = await self._async_request("post", "/api/bookmarks/", json=payload)
+        return cast(Dict[str, Any], data)
 
     async def async_get_single(self, bookmark_id: int) -> dict[str, Any]:
         """Return a single bookmark."""
@@ -129,10 +108,16 @@ class BookmarkManager:
         tag_names: list[str] | None = None,
     ) -> dict[str, Any]:
         """Update an existing bookmark."""
-        return await self._async_create_or_update_bookmark(
-            url=url,
-            title=title,
-            description=description,
-            tag_names=tag_names,
-            bookmark_id=bookmark_id,
+        payload = generate_api_payload(
+            (
+                ("url", url),
+                ("title", title),
+                ("description", description),
+                ("tag_names", tag_names),
+            )
         )
+
+        data = await self._async_request(
+            "patch", f"/api/bookmarks/{bookmark_id}/", json=payload
+        )
+        return cast(Dict[str, Any], data)

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -190,7 +190,7 @@ async def test_update(aresponses, bookmarks_async_get_single_response):
     aresponses.add(
         "127.0.0.1:8000",
         "/api/bookmarks/1/",
-        "put",
+        "patch",
         aresponses.Response(
             text=json.dumps(bookmarks_async_get_single_response),
             status=200,


### PR DESCRIPTION
**Describe what the PR does:**

`client.bookmarks.async_update` never really worked as expected because linkding was using `PUT` for it's update API method – this required that all bookmarks fields be provided (which is antithetical to what "update" is supposed to do: update one or more fields). Now that [linkding supports the `PATCH` verb on that route](https://github.com/sissbruecker/linkding/pull/269), this PR makes the necessary changes here to ensure that updating works.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/aiolinkding/issues/<ISSUE ID>

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
