### PR TITLE
Add ability to flag a newly-created bookmark as shared

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ asyncio.run(main())
 * `tag_names`: the tags to assign to the bookmark (represented as a list of strings)
 * `is_archived`: whether the newly-created bookmark should automatically be archived
 * `unread`: whether the newly-created bookmark should be marked as unread
+* `shared`: whether the newly-created bookmark should be shareable with other linkding users
 
 ### Updating an Existing Bookmark by ID
 
@@ -221,6 +222,7 @@ will change that value for the existing bookmark):
 * `description`: the bookmark's description
 * `tag_names`: the tags to assign to the bookmark (represented as a list of strings)
 * `unread`: whether the bookmark should be marked as unread
+* `shared`: whether the bookmark should be shareable with other linkding users
 
 ### Archiving/Unarchiving a Bookmark
 

--- a/aiolinkding/bookmark.py
+++ b/aiolinkding/bookmark.py
@@ -77,6 +77,7 @@ class BookmarkManager:
         tag_names: list[str] | None = None,
         is_archived: bool = False,
         unread: bool = False,
+        shared: bool = False,
     ) -> dict[str, Any]:
         """Create a new bookmark."""
         payload = generate_api_payload(
@@ -87,6 +88,7 @@ class BookmarkManager:
                 ("tag_names", tag_names),
                 ("is_archived", is_archived),
                 ("unread", unread),
+                ("shared", shared),
             )
         )
 
@@ -111,6 +113,7 @@ class BookmarkManager:
         description: str | None = None,
         tag_names: list[str] | None = None,
         unread: bool = False,
+        shared: bool = False,
     ) -> dict[str, Any]:
         """Update an existing bookmark."""
         payload = generate_api_payload(
@@ -120,6 +123,7 @@ class BookmarkManager:
                 ("description", description),
                 ("tag_names", tag_names),
                 ("unread", unread),
+                ("shared", shared),
             )
         )
 

--- a/tests/fixtures/bookmarks_async_get_all_response.json
+++ b/tests/fixtures/bookmarks_async_get_all_response.json
@@ -12,6 +12,7 @@
       "website_description": "Website description",
       "is_archived": false,
       "unread": false,
+      "shared": false,
       "tag_names": [
         "tag1",
         "tag2"

--- a/tests/fixtures/bookmarks_async_get_archived_response.json
+++ b/tests/fixtures/bookmarks_async_get_archived_response.json
@@ -10,8 +10,9 @@
       "description": "Example description",
       "website_title": "Website title",
       "website_description": "Website description",
-      "is_archived": false,
+      "is_archived": true,
       "unread": false,
+      "shared": false,
       "tag_names": [
         "tag1",
         "tag2"

--- a/tests/fixtures/bookmarks_async_get_single_response.json
+++ b/tests/fixtures/bookmarks_async_get_single_response.json
@@ -7,6 +7,7 @@
   "website_description": "Website description",
   "is_archived": false,
   "unread": false,
+  "shared": false,
   "tag_names": [
     "tag1",
     "tag2"


### PR DESCRIPTION
**Describe what the PR does:**

Linkding 1.13.0 adds [the ability to mark bookmarks as shared](https://github.com/sissbruecker/linkding/pull/311). This PR adds the corresponding functionality to this library.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
