### PR TITLE
Fix issue with incorrect Python version spec

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1508,5 +1508,5 @@ multidict = ">=4.0"
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.10,<=3.12"
-content-hash = "ac52b5f712ef8728bea8c62457baaeead6f1a343f5692e316786a52b9d0cb9df"
+python-versions = "^3.10"
+content-hash = "2cc18eb312c4bfb2c7dab0f9d53f80c605bfe7a1ef8f6483daef5801c2f8ecba"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ aiohttp = ">=3.9.0"
 certifi = ">=2023.07.22"
 frozenlist = "^1.4.0"
 packaging = "^23.0"
-python = ">=3.10,<=3.12"
+python = "^3.10"
 yarl = ">=1.9.2"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
**Describe what the PR does:**

The current version spec was too restrictive and disallowed patch versions of 3.12.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
