### PR TITLE
ci: renovate use of `ruff`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,17 +85,11 @@ repos:
         language: system
         types: [python]
         entry: poetry run ruff format
-      - id: isort
-        name: 🔀 Sorting all imports with isort
-        language: system
-        types: [python]
-        entry: poetry run isort
       - id: mypy
         name: 🆎 Performing static type checking using mypy
         language: system
         types: [python]
         entry: poetry run mypy
-        require_serial: true
       - id: no-commit-to-branch
         name: 🛑 Checking for commit to protected branch
         language: system
@@ -116,35 +110,17 @@ repos:
         language: system
         types: [python]
         entry: poetry run pylint
-      - id: pyupgrade
-        name: 🆙 Checking for upgradable syntax with pyupgrade
+      - id: ruff
+        name: 👔 Enforcing style guide with ruff
         language: system
         types: [python]
-        entry: poetry run pyupgrade
-        args: [--py39-plus, --keep-runtime-typing]
+        entry: poetry run ruff check --fix
       - id: trailing-whitespace
         name: ✄  Trimming trailing whitespace
         language: system
         types: [text]
         entry: poetry run trailing-whitespace-fixer
         stages: [commit, push, manual]
-      - id: ruff
-        name: 👔 Enforcing style guide with ruff
-        language: system
-        types: [python]
-        entry: poetry run ruff --fix
-      - id: vulture
-        name: 🔍 Finding unused Python code with Vulture
-        language: system
-        types: [python]
-        entry: poetry run vulture
-        pass_filenames: false
-        require_serial: true
-      - id: yamllint
-        name: 🎗  Checking YAML files with yamllint
-        language: system
-        types: [yaml]
-        entry: poetry run yamllint
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v3.0.0-alpha.4"

--- a/aiolinkding/__init__.py
+++ b/aiolinkding/__init__.py
@@ -1,3 +1,8 @@
-"""Define the aiowatttime package."""
+"""Define the aiolinkding package."""
 
-from .client import Client, async_get_client  # noqa
+from .client import Client, async_get_client
+
+__all__ = [
+    "Client",
+    "async_get_client",
+]

--- a/aiolinkding/bookmark.py
+++ b/aiolinkding/bookmark.py
@@ -15,7 +15,9 @@ class BookmarkManager:
         """Initialize.
 
         Args:
+        ----
             async_request: The request method from the Client object.
+
         """
         self._async_request = async_request
 
@@ -30,13 +32,16 @@ class BookmarkManager:
         """Return all bookmarks.
 
         Args:
+        ----
             archived: Include archived bookmarks.
             query: Return bookmarks matching a query string.
             limit: Limit the number of returned bookmarks.
             offset: The index at which to return results.
 
         Returns:
+        -------
             An API response payload.
+
         """
         params = generate_api_payload(
             (
@@ -56,7 +61,9 @@ class BookmarkManager:
         """Archive a bookmark.
 
         Args:
+        ----
             bookmark_id: The ID of the bookmark to archive.
+
         """
         await self._async_request("post", f"/api/bookmarks/{bookmark_id}/archive/")
 
@@ -64,7 +71,9 @@ class BookmarkManager:
         """Delete a bookmark.
 
         Args:
+        ----
             bookmark_id: The ID of the bookmark to delete.
+
         """
         await self._async_request("delete", f"/api/bookmarks/{bookmark_id}/")
 
@@ -78,12 +87,15 @@ class BookmarkManager:
         """Return all bookmarks.
 
         Args:
+        ----
             query: Return bookmarks matching a query string.
             limit: Limit the number of returned bookmarks.
             offset: The index at which to return results.
 
         Returns:
+        -------
             An API response payload.
+
         """
         return await self._async_get_bookmarks(query=query, limit=limit, offset=offset)
 
@@ -97,18 +109,21 @@ class BookmarkManager:
         """Return all archived bookmarks.
 
         Args:
+        ----
             query: Return bookmarks matching a query string.
             limit: Limit the number of returned bookmarks.
             offset: The index at which to return results.
 
         Returns:
+        -------
             An API response payload.
+
         """
         return await self._async_get_bookmarks(
             archived=True, query=query, limit=limit, offset=offset
         )
 
-    async def async_create(  # pylint: disable=too-many-arguments
+    async def async_create(
         self,
         url: str,
         *,
@@ -123,6 +138,7 @@ class BookmarkManager:
         """Create a new bookmark.
 
         Args:
+        ----
             url: The bookmark URL.
             title: The bookmark title.
             description: The bookmark description.
@@ -133,7 +149,9 @@ class BookmarkManager:
             shared: Immediately mark the bookmark as shared.
 
         Returns:
+        -------
             An API response payload.
+
         """
         payload = generate_api_payload(
             (
@@ -154,10 +172,13 @@ class BookmarkManager:
         """Return a single bookmark.
 
         Args:
+        ----
             bookmark_id: The ID of the bookmark to get.
 
         Returns:
+        -------
             An API response payload.
+
         """
         return await self._async_request("get", f"/api/bookmarks/{bookmark_id}/")
 
@@ -165,11 +186,13 @@ class BookmarkManager:
         """Unarchive a bookmark.
 
         Args:
+        ----
             bookmark_id: The ID of the bookmark to unarchive.
+
         """
         await self._async_request("post", f"/api/bookmarks/{bookmark_id}/unarchive/")
 
-    async def async_update(  # pylint: disable=too-many-arguments
+    async def async_update(
         self,
         bookmark_id: int,
         *,
@@ -184,6 +207,7 @@ class BookmarkManager:
         """Update an existing bookmark.
 
         Args:
+        ----
             bookmark_id: The ID of the bookmark to update.
             url: The bookmark URL.
             title: The bookmark title.
@@ -194,7 +218,9 @@ class BookmarkManager:
             shared: Immediately mark the bookmark as shared.
 
         Returns:
+        -------
             An API response payload.
+
         """
         payload = generate_api_payload(
             (

--- a/aiolinkding/errors.py
+++ b/aiolinkding/errors.py
@@ -4,28 +4,18 @@
 class LinkDingError(Exception):
     """Define a base exception."""
 
-    pass
-
 
 class InvalidServerVersionError(LinkDingError):
     """Define an error related to an invalid server version."""
-
-    pass
 
 
 class InvalidTokenError(LinkDingError):
     """Define an error related to an invalid API token."""
 
-    pass
-
 
 class RequestError(LinkDingError):
     """An error related to invalid requests."""
 
-    pass
-
 
 class UnknownEndpointError(RequestError):
     """An error related to an unknown endpoint."""
-
-    pass

--- a/aiolinkding/tag.py
+++ b/aiolinkding/tag.py
@@ -15,7 +15,9 @@ class TagManager:
         """Initialize.
 
         Args:
+        ----
             async_request: The request method from the Client object.
+
         """
         self._async_request = async_request
 
@@ -23,10 +25,13 @@ class TagManager:
         """Create a new tag.
 
         Args:
+        ----
             tag_name: The tag to create.
 
         Returns:
+        -------
             An API response payload.
+
         """
         data = await self._async_request(
             "post", "/api/tags/", json={"example": tag_name}
@@ -42,11 +47,14 @@ class TagManager:
         """Return all tags.
 
         Args:
+        ----
             limit: Limit the number of returned tags.
             offset: The index at which to return results.
 
         Returns:
+        -------
             An API response payload.
+
         """
         params = generate_api_payload(
             (
@@ -62,10 +70,13 @@ class TagManager:
         """Return a single tag.
 
         Args:
+        ----
             tag_id: The ID of the tag to get.
 
         Returns:
+        -------
             An API response payload.
+
         """
         data = await self._async_request("get", f"/api/tags/{tag_id}/")
         return cast(dict[str, Any], data)

--- a/aiolinkding/user.py
+++ b/aiolinkding/user.py
@@ -13,15 +13,19 @@ class UserManager:  # pylint: disable=too-few-public-methods
         """Initialize.
 
         Args:
+        ----
             async_request: The request method from the Client object.
+
         """
         self._async_request = async_request
 
     async def async_get_profile(self) -> dict[str, Any]:
         """Return user profile info.
 
-        Returns:
+        Returns
+        -------
             An API response payload.
+
         """
         data = await self._async_request("get", "/api/user/profile/")
         return cast(dict[str, Any], data)

--- a/aiolinkding/util/__init__.py
+++ b/aiolinkding/util/__init__.py
@@ -9,10 +9,13 @@ def generate_api_payload(param_pairs: tuple) -> dict[str, Any]:
     """Generate an aiolinkding payload dict from parameters.
 
     Args:
+    ----
         param_pairs: A tuple of parameter key/values.
 
     Returns:
+    -------
         An API response payload.
+
     """
     payload = {}
 

--- a/examples/test_client.py
+++ b/examples/test_client.py
@@ -43,8 +43,8 @@ async def main() -> None:
 
             tags = await client.tags.async_get_all()
             _LOGGER.info("tags: %s", tags)
-        except LinkDingError as err:
-            _LOGGER.error("There was an error: %s", err)
+        except LinkDingError:
+            _LOGGER.exception("There was an error: %s")
 
 
 asyncio.run(main())

--- a/poetry.lock
+++ b/poetry.lock
@@ -1343,20 +1343,6 @@ docs = ["furo (>=2022.12.7)", "proselint (>=0.13)", "sphinx (>=6.1.3)", "sphinx-
 test = ["covdefaults (>=2.2.2)", "coverage (>=7.1)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23)", "pytest (>=7.2.1)", "pytest-env (>=0.8.1)", "pytest-freezegun (>=0.4.2)", "pytest-mock (>=3.10)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)"]
 
 [[package]]
-name = "vulture"
-version = "2.11"
-description = "Find dead code"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "vulture-2.11-py2.py3-none-any.whl", hash = "sha256:12d745f7710ffbf6aeb8279ba9068a24d4e52e8ed333b8b044035c9d6b823aba"},
-    {file = "vulture-2.11.tar.gz", hash = "sha256:f0fbb60bce6511aad87ee0736c502456737490a82d919a44e6d92262cb35f1c2"},
-]
-
-[package.dependencies]
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-
-[[package]]
 name = "yamllint"
 version = "1.35.1"
 description = "A linter for YAML files."
@@ -1480,4 +1466,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "130b91a4b5863fe892e0d40024def9f9c78bd40c8e24ac91419e1064159bb77c"
+content-hash = "92463de9fc3781bb651ffcecbeeae748615c95a6a4d3b2dddf62f087b96a1367"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,6 @@ pyyaml = "^6.0.1"
 requests = ">=2.31.0"
 ruff = ">=0.0.261,<0.3.5"
 typing-extensions = "^4.8.0"
-vulture = "^2.6"
 yamllint = "^1.28.0"
 
 [tool.poetry.urls]
@@ -96,6 +95,7 @@ yamllint = "^1.28.0"
 Changelog = "https://github.com/bachya/aiolinkding/releases"
 
 [tool.pylint.BASIC]
+class-const-naming-style = "any"
 expected-line-ending-format = "LF"
 
 [tool.pylint.DESIGN]
@@ -104,46 +104,306 @@ max-attributes = 20
 [tool.pylint.FORMAT]
 max-line-length = 88
 
-[tool.pylint.MASTER]
+[tool.pylint.MAIN]
+py-version = "3.12"
 ignore = [
-  "tests",
+    "tests",
 ]
+# Use a conservative default here; 2 should speed up most setups and not hurt
+# any too bad. Override on command line as appropriate.
+jobs = 2
+init-hook = """\
+    from pathlib import Path; \
+    import sys; \
+
+    from pylint.config import find_default_config_files; \
+
+    sys.path.append( \
+        str(Path(next(find_default_config_files())).parent.joinpath('pylint/plugins'))
+    ) \
+    """
 load-plugins = [
-  "pylint.extensions.bad_builtin",
-  "pylint.extensions.code_style",
-  "pylint.extensions.docparams",
-  "pylint.extensions.docstyle",
-  "pylint.extensions.empty_comment",
-  "pylint.extensions.overlapping_exceptions",
-  "pylint.extensions.typing",
+    "pylint.extensions.code_style",
+    "pylint.extensions.typing",
+]
+persistent = false
+fail-on = [
+    "I",
 ]
 
 [tool.pylint."MESSAGES CONTROL"]
-# Reasons disabled:
-# unnecessary-pass - This can hurt readability
 disable = [
-  "unnecessary-pass"
+    # These are subjective and should be left up to the developer:
+    "too-many-arguments",
+    "too-many-lines",
+    "too-many-locals",
+    "duplicate-code",
+
+    # Handled by ruff:
+    # Ref: <https://github.com/astral-sh/ruff/issues/970>
+    "anomalous-backslash-in-string",        # W605
+    "assert-on-string-literal",             # PLW0129
+    "assert-on-tuple",                      # F631
+    "await-outside-async",                  # PLE1142
+    "bad-classmethod-argument",             # N804
+    "bad-format-string",                    # W1302, F
+    "bad-format-string-key",                # W1300, F
+    "bad-str-strip-call",                   # PLE1310
+    "bad-string-format-type",               # PLE1307
+    "bare-except",                          # E722
+    "bidirectional-unicode",                # PLE2502
+    "binary-op-exception",                  # PLW0711
+    "broad-exception-caught",               # W0718
+    "cell-var-from-loop",                   # B023
+    "comparison-of-constants",              # PLR0133
+    "comparison-with-itself",               # PLR0124
+    "consider-alternative-union-syntax",    # UP007
+    "consider-iterating-dictionary",        # SIM118
+    "consider-merging-isinstance",          # PLR1701
+    "consider-using-alias",                 # UP006
+    "consider-using-dict-comprehension",    # C402
+    "consider-using-generator",             # C417
+    "consider-using-get",                   # SIM401
+    "consider-using-set-comprehension",     # C401
+    "consider-using-sys-exit",              # PLR1722
+    "consider-using-ternary",               # SIM108
+    "continue-in-finally",                  # PLE0116
+    "duplicate-bases",                      # PLE0241
+    "duplicate-except",                     # B014
+    "duplicate-key",                        # F601
+    "duplicate-string-formatting-argument", # F
+    "duplicate-value",                      # F
+    "empty-docstring",                      # D419
+    "eval-used",                            # S307
+    "exec-used",                            # S102
+    "expression-not-assigned",              # B018
+    "f-string-without-interpolation",       # F541
+    "forgotten-debug-statement",            # T100
+    "format-needs-mapping",                 # F502
+    "format-string-without-interpolation",  # F
+    "function-redefined",                   # F811
+    "global-variable-not-assigned",         # PLW0602
+    "implicit-str-concat",                  # ISC001
+    "import-self",                          # PLW0406
+    "inconsistent-quotes",                  # Q000
+    "invalid-all-object",                   # PLE0604
+    "invalid-character-backspace",          # PLE2510
+    "invalid-character-esc",                # PLE2513
+    "invalid-character-nul",                # PLE2514
+    "invalid-character-sub",                # PLE2512
+    "invalid-character-zero-width-space",   # PLE2515
+    "invalid-envvar-default",               # PLW1508
+    "invalid-name",                         # N815
+    "keyword-arg-before-vararg",            # B026
+    "line-too-long",                        # E501
+    "literal-comparison",                   # F632
+    "logging-format-interpolation",         # G
+    "logging-fstring-interpolation",        # G
+    "logging-not-lazy",                     # G
+    "logging-too-few-args",                 # PLE1206
+    "logging-too-many-args",                # PLE1205
+    "misplaced-future",                     # F404
+    "missing-class-docstring",              # D101
+    "missing-final-newline",                # W292
+    "missing-format-string-key",            # F524
+    "missing-function-docstring",           # D103
+    "missing-module-docstring",             # D100
+    "mixed-format-string",                  # F506
+    "multiple-imports",                     #E401
+    "named-expr-without-context",           # PLW0131
+    "nested-min-max",                       # PLW3301
+    "no-method-argument",                   # N805
+    "no-self-argument",                     # N805
+    "nonexistent-operator",                 # B002
+    "nonlocal-without-binding",             # PLE0117
+    "not-in-loop",                          # F701, F702
+    "notimplemented-raised",                # F901
+    "pointless-statement",                  # B018
+    "property-with-parameters",             # PLR0206
+    "raise-missing-from",                   # B904
+    "return-in-init",                       # PLE0101
+    "return-outside-function",              # F706
+    "singleton-comparison",                 # E711, E712
+    "subprocess-run-check",                 # PLW1510
+    "super-with-arguments",                 # UP008
+    "superfluous-parens",                   # UP034
+    "syntax-error",                         # E999
+    "too-few-format-args",                  # F524
+    "too-many-branches",                    # PLR0912
+    "too-many-format-args",                 # F522
+    "too-many-return-statements",           # PLR0911
+    "too-many-star-expressions",            # F622
+    "too-many-statements",                  # PLR0915
+    "trailing-comma-tuple",                 # COM818
+    "truncated-format-string",              # F501
+    "try-except-raise",                     # TRY302
+    "undefined-all-variable",               # F822
+    "undefined-variable",                   # F821
+    "ungrouped-imports",                    # I001
+    "unidiomatic-typecheck",                # E721
+    "unnecessary-comprehension",            # C416
+    "unnecessary-direct-lambda-call",       # PLC3002
+    "unnecessary-lambda-assignment",        # PLC3001
+    "unnecessary-pass",                     # PIE790
+    "unneeded-not",                         # SIM208
+    "unused-argument",                      # ARG001
+    "unused-format-string-argument",        # F507
+    "unused-format-string-key",             # F504
+    "unused-import",                        # F401
+    "unused-variable",                      # F841
+    "use-a-generator",                      # C417
+    "use-dict-literal",                     # C406
+    "use-list-literal",                     # C405
+    "used-prior-global-declaration",        # PLE0118
+    "useless-else-on-loop",                 # PLW0120
+    "useless-import-alias",                 # PLC0414
+    "useless-object-inheritance",           # UP004
+    "useless-return",                       # PLR1711
+    "wildcard-import",                      # F403
+    "wrong-import-order",                   # I001
+    "wrong-import-position",                # E402
+    "yield-inside-async-function",          # PLE1700
+    "yield-outside-function",               # F704
+
+    # Handled by mypy:
+    # Ref: <https://github.com/antonagestam/pylint-mypy-overlap>
+    "abstract-class-instantiated",
+    "arguments-differ",
+    "assigning-non-slot",
+    "assignment-from-no-return",
+    "assignment-from-none",
+    "bad-exception-cause",
+    "bad-format-character",
+    "bad-reversed-sequence",
+    "bad-super-call",
+    "bad-thread-instantiation",
+    "catching-non-exception",
+    "comparison-with-callable",
+    "deprecated-class",
+    "dict-iter-missing-items",
+    "format-combined-specification",
+    "global-variable-undefined",
+    "import-error",
+    "inconsistent-mro",
+    "inherit-non-class",
+    "init-is-generator",
+    "invalid-class-object",
+    "invalid-enum-extension",
+    "invalid-envvar-value",
+    "invalid-format-returned",
+    "invalid-hash-returned",
+    "invalid-metaclass",
+    "invalid-overridden-method",
+    "invalid-repr-returned",
+    "invalid-sequence-index",
+    "invalid-slice-index",
+    "invalid-slots",
+    "invalid-slots-object",
+    "invalid-star-assignment-target",
+    "invalid-str-returned",
+    "invalid-unary-operand-type",
+    "invalid-unicode-codec",
+    "isinstance-second-argument-not-valid-type",
+    "method-hidden",
+    "misplaced-format-function",
+    "missing-format-argument-key",
+    "missing-format-attribute",
+    "missing-kwoa",
+    "no-member",
+    "no-value-for-parameter",
+    "non-iterator-returned",
+    "non-str-assignment-to-dunder-name",
+    "nonlocal-and-global",
+    "not-a-mapping",
+    "not-an-iterable",
+    "not-async-context-manager",
+    "not-callable",
+    "not-context-manager",
+    "overridden-final-method",
+    "raising-bad-type",
+    "raising-non-exception",
+    "redundant-keyword-arg",
+    "relative-beyond-top-level",
+    "self-cls-assignment",
+    "signature-differs",
+    "star-needs-assignment-target",
+    "subclassed-final-class",
+    "super-without-brackets",
+    "too-many-function-args",
+    "typevar-double-variance",
+    "typevar-name-mismatch",
+    "unbalanced-dict-unpacking",
+    "unbalanced-tuple-unpacking",
+    "unexpected-keyword-arg",
+    "unhashable-member",
+    "unpacking-non-sequence",
+    "unsubscriptable-object",
+    "unsupported-assignment-operation",
+    "unsupported-binary-operation",
+    "unsupported-delete-operation",
+    "unsupported-membership-test",
+    "used-before-assignment",
+    "using-final-decorator-in-unsupported-version",
+    "wrong-exception-operation",
+]
+enable = [
+    "useless-suppression",
+    "use-symbolic-message-instead",
 ]
 
-[tool.pylint.REPORTS]
-score = false
+[tool.pylint.TYPING]
+runtime-typing = false
 
-[tool.pylint.SIMILARITIES]
-# Minimum lines number of a similarity.
-# We set this higher because of some cases where V2 and V3 functionality are
-# similar, but abstracting them isn't feasible.
-min-similarity-lines = 8
+[tool.pylint.CODE_STYLE]
+max-line-length-suggestions = 72
 
-# Ignore comments when computing similarities.
-ignore-comments = true
+[tool.ruff.lint]
+select = [
+    "ALL"
+]
 
-# Ignore docstrings when computing similarities.
-ignore-docstrings = true
+ignore = [
+    "ANN101",  # Missing type annotation for self
+    "D202",    # No blank lines allowed after function docstring
+    "D203",    # 1 blank line required before class docstring
+    "PLR0913", # This is subjective
+    "PLW2901", # Outer {outer_kind} variable {name} overwritten by inner {inner_kind} target
+    "PT012",   # `pytest.raises()` block should contain a single simple statement
+    "TCH",     # flake8-type-checking
 
-# Ignore imports when computing similarities.
-ignore-imports = true
+    # May conflict with the formatter:
+    # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+    "COM812",
+    "COM819",
+    "D206",
+    "D300",
+    "E111",
+    "E114",
+    "E117",
+    "ISC001",
+    "ISC002",
+    "Q000",
+    "Q001",
+    "Q002",
+    "Q003",
+    "W191",
+]
 
-[tool.vulture]
-min_confidence = 80
-paths = ["aiolinkding", "tests"]
-verbose = false
+[tool.ruff.lint.isort]
+force-sort-within-sections = true
+known-first-party = [
+    "aiolinkding",
+    "examples",
+    "tests",
+]
+combine-as-imports = true
+split-on-trailing-comma = false
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = [
+    "ARG001",   # Tests ofen have unused arguments
+    "FBT001",   # Test fixtures may be boolean values
+    "PLR2004",  # Checking for magic values in tests isn't helpful
+    "S101",     # Assertions are fine in tests
+    "SLF001",   # We'll access a lot of private third-party members in tests
+]

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,6 +1,6 @@
 """Define common test utilities."""
 
-import os
+from pathlib import Path
 
 TEST_TOKEN = "abcde12345"  # noqa: S105
 TEST_URL = "http://127.0.0.1:8000"
@@ -10,11 +10,14 @@ def load_fixture(filename: str) -> str:
     """Load a fixture.
 
     Args:
+    ----
         filename: The filename of the fixtures/ file to load.
 
     Returns:
+    -------
         A string containing the contents of the file.
+
     """
-    path = os.path.join(os.path.dirname(__file__), "fixtures", filename)
-    with open(path, encoding="utf-8") as fptr:
+    path = Path(f"{Path(__file__).parent}/fixtures/{filename}")
+    with Path.open(path, encoding="utf-8") as fptr:
         return fptr.read()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,13 @@
 """Define dynamic fixtures."""
 
+from __future__ import annotations
+
 import json
-from collections.abc import Generator
 from typing import Any, cast
 
 import aiohttp
-import pytest
 from aresponses import ResponsesMockServer
+import pytest
 
 from aiolinkding.client import SERVER_VERSION_MINIMUM_REQUIRED
 from tests.common import load_fixture
@@ -15,11 +16,13 @@ from tests.common import load_fixture
 @pytest.fixture(name="authenticated_linkding_api_server")
 def authenticated_linkding_api_server_fixture(
     health_response: dict[str, Any],
-) -> Generator[ResponsesMockServer, None, None]:
+) -> ResponsesMockServer:
     """Return a fixture that mocks an authenticated linkding API server.
 
     Args:
+    ----
         health_response: An API response payload
+
     """
     server = ResponsesMockServer()
     server.add(
@@ -28,7 +31,7 @@ def authenticated_linkding_api_server_fixture(
         "get",
         response=aiohttp.web_response.json_response(health_response, status=200),
     )
-    yield server
+    return server
 
 
 @pytest.fixture(name="bookmarks_async_get_all_response", scope="session")

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -1,17 +1,19 @@
 """Define tests for bookmark endpoints."""
 
+from __future__ import annotations
+
 from typing import Any
 
 import aiohttp
-import pytest
 from aresponses import ResponsesMockServer
+import pytest
 
 from aiolinkding import async_get_client
 
 from .common import TEST_TOKEN, TEST_URL
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_archive(
     aresponses: ResponsesMockServer,
     authenticated_linkding_api_server: ResponsesMockServer,
@@ -19,8 +21,10 @@ async def test_archive(
     """Test archiving a bookmark.
 
     Args:
+    ----
         aresponses: An aresponses server.
         authenticated_linkding_api_server: A mock authenticated linkding API server.
+
     """
     async with authenticated_linkding_api_server:
         authenticated_linkding_api_server.add(
@@ -37,7 +41,7 @@ async def test_archive(
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_create(
     aresponses: ResponsesMockServer,
     authenticated_linkding_api_server: ResponsesMockServer,
@@ -46,9 +50,11 @@ async def test_create(
     """Test creating a single bookmark.
 
     Args:
+    ----
         aresponses: An aresponses server.
         authenticated_linkding_api_server: A mock authenticated linkding API server.
         bookmarks_async_get_single_response: An API response payload.
+
     """
     async with authenticated_linkding_api_server:
         authenticated_linkding_api_server.add(
@@ -76,7 +82,7 @@ async def test_create(
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_delete(
     aresponses: ResponsesMockServer,
     authenticated_linkding_api_server: ResponsesMockServer,
@@ -84,8 +90,10 @@ async def test_delete(
     """Test deleting a bookmark.
 
     Args:
+    ----
         aresponses: An aresponses server.
         authenticated_linkding_api_server: A mock authenticated linkding API server.
+
     """
     async with authenticated_linkding_api_server:
         authenticated_linkding_api_server.add(
@@ -102,7 +110,7 @@ async def test_delete(
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_get_all(
     aresponses: ResponsesMockServer,
     authenticated_linkding_api_server: ResponsesMockServer,
@@ -111,9 +119,11 @@ async def test_get_all(
     """Test getting all bookmarks.
 
     Args:
+    ----
         aresponses: An aresponses server.
         authenticated_linkding_api_server: A mock authenticated linkding API server.
         bookmarks_async_get_all_response: An API response payload.
+
     """
     async with authenticated_linkding_api_server:
         authenticated_linkding_api_server.add(
@@ -135,7 +145,7 @@ async def test_get_all(
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_get_all_no_explicit_session(
     aresponses: ResponsesMockServer,
     authenticated_linkding_api_server: ResponsesMockServer,
@@ -144,9 +154,11 @@ async def test_get_all_no_explicit_session(
     """Test getting all bookmarks without an explicit ClientSession.
 
     Args:
+    ----
         aresponses: An aresponses server.
         authenticated_linkding_api_server: A mock authenticated linkding API server.
         bookmarks_async_get_all_response: An API response payload.
+
     """
     async with authenticated_linkding_api_server:
         authenticated_linkding_api_server.add(
@@ -167,7 +179,7 @@ async def test_get_all_no_explicit_session(
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_get_archived(
     aresponses: ResponsesMockServer,
     authenticated_linkding_api_server: ResponsesMockServer,
@@ -176,9 +188,11 @@ async def test_get_archived(
     """Test getting archived bookmarks.
 
     Args:
+    ----
         aresponses: An aresponses server.
         authenticated_linkding_api_server: A mock authenticated linkding API server.
         bookmarks_async_get_archived_response: An API response payload.
+
     """
     async with authenticated_linkding_api_server:
         authenticated_linkding_api_server.add(
@@ -198,7 +212,7 @@ async def test_get_archived(
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_get_single(
     aresponses: ResponsesMockServer,
     authenticated_linkding_api_server: ResponsesMockServer,
@@ -207,9 +221,11 @@ async def test_get_single(
     """Test getting a single bookmark.
 
     Args:
+    ----
         aresponses: An aresponses server.
         authenticated_linkding_api_server: A mock authenticated linkding API server.
         bookmarks_async_get_single_response: An API response payload.
+
     """
     async with authenticated_linkding_api_server:
         authenticated_linkding_api_server.add(
@@ -229,7 +245,7 @@ async def test_get_single(
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_unarchive(
     aresponses: ResponsesMockServer,
     authenticated_linkding_api_server: ResponsesMockServer,
@@ -237,8 +253,10 @@ async def test_unarchive(
     """Test unarchiving a bookmark.
 
     Args:
+    ----
         aresponses: An aresponses server.
         authenticated_linkding_api_server: A mock authenticated linkding API server.
+
     """
     async with authenticated_linkding_api_server:
         authenticated_linkding_api_server.add(
@@ -255,7 +273,7 @@ async def test_unarchive(
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_update(
     aresponses: ResponsesMockServer,
     authenticated_linkding_api_server: ResponsesMockServer,
@@ -264,9 +282,11 @@ async def test_update(
     """Test creating a single bookmark.
 
     Args:
+    ----
         aresponses: An aresponses server.
         authenticated_linkding_api_server: A mock authenticated linkding API server.
         bookmarks_async_get_single_response: An API response payload.
+
     """
     async with authenticated_linkding_api_server:
         authenticated_linkding_api_server.add(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,10 +1,12 @@
 """Define tests for the client."""
 
+from __future__ import annotations
+
 from typing import Any
 
 import aiohttp
-import pytest
 from aresponses import ResponsesMockServer
+import pytest
 
 from aiolinkding import async_get_client
 from aiolinkding.client import (
@@ -20,14 +22,16 @@ from aiolinkding.errors import (
 from .common import TEST_TOKEN, TEST_URL
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_health_endpiont_missing(
     aresponses: ResponsesMockServer,
 ) -> None:
     """Test an API call when /health missing.
 
     Args:
+    ----
         aresponses: An aresponses server.
+
     """
     aresponses.add(
         "127.0.0.1:8000",
@@ -49,7 +53,7 @@ async def test_health_endpiont_missing(
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "health_response",
     [
@@ -66,8 +70,10 @@ async def test_invalid_server_version(
     """Test an API call with an invalid server version.
 
     Args:
+    ----
         aresponses: An aresponses server.
         health_response: An API response payload.
+
     """
     aresponses.add(
         "127.0.0.1:8000",
@@ -87,7 +93,7 @@ async def test_invalid_server_version(
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_invalid_token(
     aresponses: ResponsesMockServer,
     authenticated_linkding_api_server: ResponsesMockServer,
@@ -96,9 +102,11 @@ async def test_invalid_token(
     """Test an API call with an invalid token.
 
     Args:
+    ----
         aresponses: An aresponses server.
         authenticated_linkding_api_server: A mock authenticated linkding API server.
         invalid_token_response: An API response payload.
+
     """
     async with authenticated_linkding_api_server:
         authenticated_linkding_api_server.add(
@@ -118,7 +126,7 @@ async def test_invalid_token(
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_request_error(
     aresponses: ResponsesMockServer,
     authenticated_linkding_api_server: ResponsesMockServer,
@@ -127,9 +135,11 @@ async def test_request_error(
     """Test an API call with a general request error.
 
     Args:
+    ----
         aresponses: An aresponses server.
         authenticated_linkding_api_server: A mock authenticated linkding API server.
         missing_field_response: An API response payload.
+
     """
     async with authenticated_linkding_api_server:
         authenticated_linkding_api_server.add(

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,17 +1,19 @@
 """Define tests for tag endpoints."""
 
+from __future__ import annotations
+
 from typing import Any
 
 import aiohttp
-import pytest
 from aresponses import ResponsesMockServer
+import pytest
 
 from aiolinkding import async_get_client
 
 from .common import TEST_TOKEN, TEST_URL
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_create(
     aresponses: ResponsesMockServer,
     authenticated_linkding_api_server: ResponsesMockServer,
@@ -20,9 +22,11 @@ async def test_create(
     """Test creating a single tag.
 
     Args:
+    ----
         aresponses: An aresponses server.
         authenticated_linkding_api_server: A mock authenticated linkding API server.
         tags_async_get_single_response: An API response payload.
+
     """
     async with authenticated_linkding_api_server:
         authenticated_linkding_api_server.add(
@@ -42,7 +46,7 @@ async def test_create(
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_get_all(
     aresponses: ResponsesMockServer,
     authenticated_linkding_api_server: ResponsesMockServer,
@@ -51,9 +55,11 @@ async def test_get_all(
     """Test getting all tags.
 
     Args:
+    ----
         aresponses: An aresponses server.
         authenticated_linkding_api_server: A mock authenticated linkding API server.
         tags_async_get_all_response: An API response payload.
+
     """
     async with authenticated_linkding_api_server:
         authenticated_linkding_api_server.add(
@@ -75,7 +81,7 @@ async def test_get_all(
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_get_single(
     aresponses: ResponsesMockServer,
     authenticated_linkding_api_server: ResponsesMockServer,
@@ -84,9 +90,11 @@ async def test_get_single(
     """Test getting a single tag.
 
     Args:
+    ----
         aresponses: An aresponses server.
         authenticated_linkding_api_server: A mock authenticated linkding API server.
         tags_async_get_single_response: An API response payload.
+
     """
     async with authenticated_linkding_api_server:
         authenticated_linkding_api_server.add(

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,17 +1,19 @@
 """Define tests for user endpoints."""
 
+from __future__ import annotations
+
 from typing import Any
 
 import aiohttp
-import pytest
 from aresponses import ResponsesMockServer
+import pytest
 
 from aiolinkding import async_get_client
 
 from .common import TEST_TOKEN, TEST_URL
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_get_profile(
     aresponses: ResponsesMockServer,
     authenticated_linkding_api_server: ResponsesMockServer,
@@ -20,9 +22,11 @@ async def test_get_profile(
     """Test getting all tags.
 
     Args:
+    ----
         aresponses: An aresponses server.
         authenticated_linkding_api_server: A mock authenticated linkding API server.
         user_async_get_profile_response: An API response payload.
+
     """
     async with authenticated_linkding_api_server:
         authenticated_linkding_api_server.add(


### PR DESCRIPTION
**Describe what the PR does:**

This PR uses more of `ruff`'s ruleset, which allows us to (a) be more conforming across the board, (b) eliminate redundant `pylint` and `mypy` checks, and (c) remove several redundant `pre-commit` hooks.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
